### PR TITLE
Exclude own event when calculating new ELO rating

### DIFF
--- a/app/Jobs/CalculateEloRatingJob.php
+++ b/app/Jobs/CalculateEloRatingJob.php
@@ -101,7 +101,9 @@ class CalculateEloRatingJob implements ShouldQueue, ShouldBeUnique
                                 'event',
                                 function ($query) use ($event) {
                                     $query
-                                        ->where('start_date', '<=', $event->start_date);
+                                        ->where('status', 1)
+                                        ->where('start_date', '<=', $event->start_date)
+                                        ->where('id', '!=', $event->id);
                                 }
                             )
                             ->orderBy(
@@ -126,7 +128,9 @@ class CalculateEloRatingJob implements ShouldQueue, ShouldBeUnique
                                             'event',
                                             function ($query) use ($event) {
                                                 $query
-                                                    ->where('start_date', '<=', $event->start_date);
+                                                    ->where('status', 1)
+                                                    ->where('start_date', '<=', $event->start_date)
+                                                    ->where('id', '!=', $event->id);
                                             }
                                         )
                                         ->orderBy(
@@ -156,8 +160,6 @@ class CalculateEloRatingJob implements ShouldQueue, ShouldBeUnique
                             ->push($userEventData);
                     });
 
-
-
                 // Team ELO rating 
                 $lastEloRating = optional(UserEloRating::query()
                     ->where('objectable_type', $objectableType)
@@ -168,7 +170,9 @@ class CalculateEloRatingJob implements ShouldQueue, ShouldBeUnique
                         'event',
                         function ($query) use ($event) {
                             $query
-                                ->where('start_date', '<=', $event->start_date);
+                                ->where('status', 1)
+                                ->where('start_date', '<=', $event->start_date)
+                                ->where('id', '!=', $event->id);
                         }
                     )
                     ->orderBy(
@@ -194,7 +198,9 @@ class CalculateEloRatingJob implements ShouldQueue, ShouldBeUnique
                         'event',
                         function ($query) use ($event) {
                             $query
-                                ->where('start_date', '<=', $event->start_date);
+                                ->where('status', 1)
+                                ->where('start_date', '<=', $event->start_date)
+                                ->where('id', '!=', $event->id);
                         }
                     )
                     ->orderBy(
@@ -206,7 +212,7 @@ class CalculateEloRatingJob implements ShouldQueue, ShouldBeUnique
                     ->first())
                     ->elo_rating ?? $eloConfig['defaultRating'];
 
-                $newEloRating = EloSupport::calculateTeamEloRating(+$teamResult->score, +$opponentResult->score, +$lastEloRating, +$opponentEloRating);
+                $newEloRating = EloSupport::calculateEloRating(+$teamResult->score, +$opponentResult->score, +$lastEloRating, +$opponentEloRating);
 
                 $userEventData = [];
 

--- a/app/Support/EloSupport.php
+++ b/app/Support/EloSupport.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Config;
 class EloSupport
 {
     /**
-     * Calculate the elo rating based on scores and elo ratings for team
+     * Calculate the elo rating based on scores and elo ratings
      * According to: https://en.wikipedia.org/wiki/Elo_rating_system#Mathematical_details
      *
      * @param int $ownScore
@@ -19,7 +19,7 @@ class EloSupport
      * @author Sander van Ooijen <sandervo+github@proton.me>
      * @version 1.0.0
      */
-    public static function calculateTeamEloRating(int $ownScore, int $opponentScore, int $ownEloRating, int $opponentEloRating)
+    public static function calculateEloRating(int $ownScore, int $opponentScore, int $ownEloRating, int $opponentEloRating)
     {
         $eloConfig = Config::get('elo');
 
@@ -43,20 +43,9 @@ class EloSupport
      */
     public static function calculateTeamUserEloRating(int $ownScore, int $opponentScore, int $ownEloRating, Collection $opponentEloRatings)
     {
-        $eloConfig = Config::get('elo');
+        $opponentEloRating = $opponentEloRatings->avg();
 
-        $actualScore = +$opponentScore === +$ownScore ? $eloConfig['draw'] : (+$opponentScore > +$ownScore ? $eloConfig['lose'] : $eloConfig['win']);
-
-        $expectedScore = 0;
-
-        $opponentEloRatings
-            ->each(function (int $opponentEloRating) use (&$expectedScore, $ownEloRating) {
-                $expectedScore += self::calculateExpectedScore($opponentEloRating, $ownEloRating);
-            });
-
-        $expectedScore = $expectedScore / $opponentEloRatings->count();
-
-        return round(+$ownEloRating + $eloConfig['kFactor'] * (+$actualScore - +$expectedScore), 0);
+        return self::calculateEloRating($ownScore, $opponentScore, $ownEloRating, $opponentEloRating);
     }
 
     /**

--- a/tests/Unit/Jobs/CreateEloRatingJobTest.php
+++ b/tests/Unit/Jobs/CreateEloRatingJobTest.php
@@ -93,14 +93,14 @@ class CreateEloRatingJobTest extends TestCase
             ]);
 
         // Act
-        $job = new CalculateEloRatingJob($event);
+        $job = new CalculateEloRatingJob($event->id);
         $job->handle();
 
         // Assert
         $eloRatings = UserEloRating::get();
 
-        $newTeamOwnEloRating = EloSupport::calculateTeamEloRating(+$teamResult->score, +$opponentTeamResult->score, +$eloConfig['defaultRating'], +$eloConfig['defaultRating']);
-        $opponentTeamOwnEloRating = EloSupport::calculateTeamEloRating(+$opponentTeamResult->score, +$teamResult->score, +$eloConfig['defaultRating'], +$eloConfig['defaultRating']);
+        $newTeamOwnEloRating = EloSupport::calculateEloRating(+$teamResult->score, +$opponentTeamResult->score, +$eloConfig['defaultRating'], +$eloConfig['defaultRating']);
+        $opponentTeamOwnEloRating = EloSupport::calculateEloRating(+$opponentTeamResult->score, +$teamResult->score, +$eloConfig['defaultRating'], +$eloConfig['defaultRating']);
 
         $this->assertEquals(
             $eloRatings
@@ -202,7 +202,7 @@ class CreateEloRatingJobTest extends TestCase
                 ]);
 
             // Act
-            $job = new CalculateEloRatingJob($event);
+            $job = new CalculateEloRatingJob($event->id);
             $job->handle();
         }
 
@@ -306,8 +306,8 @@ class CreateEloRatingJobTest extends TestCase
             ->first()
             ->elo_rating;
 
-        $newOwnEloRating = EloSupport::calculateTeamEloRating(+$ownScore, +$opponentScore, +$ownOldEloRating, +$opponentOldEloRating);
-        $newOpponentEloRating = EloSupport::calculateTeamEloRating(+$opponentScore, +$ownScore, +$opponentOldEloRating, +$ownOldEloRating);
+        $newOwnEloRating = EloSupport::calculateEloRating(+$ownScore, +$opponentScore, +$ownOldEloRating, +$opponentOldEloRating);
+        $newOpponentEloRating = EloSupport::calculateEloRating(+$opponentScore, +$ownScore, +$opponentOldEloRating, +$ownOldEloRating);
 
         $newOwnUserEloRating = EloSupport::calculateTeamUserEloRating(+$ownScore, +$opponentScore, +$ownOldEloRating, collect([+$opponentOldEloRating]));
         $newOpponentUserEloRating = EloSupport::calculateTeamUserEloRating(+$opponentScore, +$ownScore, +$opponentOldEloRating, collect([+$ownOldEloRating]));


### PR DESCRIPTION
Fix latest ELO difference on leaderboard page

Exclude own event when calculating new ELO rating

Change the way ELO rating is calculated for team users

Part of '6-elo-rating-is-calculated-wrong-when-editing-results'